### PR TITLE
逻辑优化

### DIFF
--- a/apps/danmu/app.py
+++ b/apps/danmu/app.py
@@ -96,6 +96,7 @@ def get_url_dict(douban_id, title, season_number, episode_number, season, guid):
 def get_danmu():
     try:
         douban_id = request.args.get('douban_id')
+        douban_id = None if douban_id == "" or douban_id is None or douban_id == 'undefined' else douban_id
         episode_number = request.args.get('episode_number')
         title = request.args.get('title')
         season_number = request.args.get('season_number')
@@ -111,7 +112,10 @@ def get_danmu():
 
     if url is not None and url != "":
         danmu_data: RetDanMuType = download_barrage(url)
-        return danmu_data.list
+        if _type == 'json':
+            return danmu_data.list
+        else:
+            return danmu_data.xml
 
     all_danmu_data = {}
     url_dict = get_url_dict(douban_id, title, season_number, episode_number, season, guid)


### PR DESCRIPTION
1、修改豆瓣ID获取时的判断，如果没有传douban_id，需要title等参数有值，如果传递了douban_id，并且season_number不为1(兼容飞牛影视多季刮削出的豆瓣ID都是第一季的问题)，才直接使用
2、douban_id参数归一化，只要是空值统一设置为None
3、直接传递链接时判断需要返回的弹幕格式