### PR TITLE
fix: 统一字典 key 为字符串类型

### DIFF
--- a/apps/danmu/app.py
+++ b/apps/danmu/app.py
@@ -116,7 +116,7 @@ def get_url_dict(douban_id, title=None, season_number=None, episode_number=None,
             for item in url_list:
                 db.add(guid=guid, url=item, parent_guid=parent_guid)
         url_dict = {
-            episode_number: url_list
+            str(episode_number): url_list
         }
     return url_dict
 
@@ -167,7 +167,7 @@ def get_danmu():
             # 处理结果
             for result in results:
                 if result["data"] is not None:
-                    k = result["key"]
+                    k = str(result["key"])
                     if k not in all_danmu_data.keys():
                         all_danmu_data[k] = []
                     all_danmu_data[k] += result["data"].list


### PR DESCRIPTION
## 修复内容

- 将 `episode_number` 作为 key 时统一转换为字符串
- 对 `result["key"]` 做字符串化处理
- 避免部分场景下，字典 key 同时使用了 `int` 和 `str` 类型

## 关联 Issue

Fixes #83